### PR TITLE
Fix: use **kwargs for custom fossology agents

### DIFF
--- a/fossology/__init__.py
+++ b/fossology/__init__.py
@@ -6,7 +6,7 @@ import logging
 import requests
 from datetime import date, timedelta
 
-from .obj import Agents, User, SearchTypes
+from .obj import Agents, User, TokenScope, SearchTypes
 from .folders import Folders
 from .uploads import Uploads
 from .jobs import Jobs
@@ -18,23 +18,30 @@ logger.setLevel(logging.DEBUG)
 
 
 def fossology_token(
-    url, username, password, token_name, token_scope, token_expire=None
+    url, username, password, token_name, token_scope=TokenScope.READ, token_expire=None
 ):
     """Generate an API token using username/password
 
     API endpoint: POST /tokens
 
+    :Example:
+
+    >>> from fossology import fossology_token
+    >>> from fossology.obj import TokenScope
+    >>> token = fossology_token("https://fossology.example.com", "Me", "MyPassword", "MyToken")
+
+
     :param url: the URL of the Fossology server
     :param username: name of the user the token will be generated for
     :param password: the password of the user
     :param name: the name of the token
-    :param scope: the scope of the token
+    :param scope: the scope of the token (default: READ)
     :param expire: the expire date of the token (default max. 30 days)
     :type url: string
     :type username: string
     :type password: string
     :type name: string
-    :type scope: string
+    :type scope: TokenScope (default TokenScope.READ)
     :type expire: string, e.g. 2019-12-25
     :return: the new token
     :rtype: string
@@ -70,7 +77,7 @@ class Fossology(Folders, Uploads, Jobs, Report):
 
     :Example:
 
-    >>> from fossology.api import Fossology
+    >>> from fossology import Fossology
     >>> foss = Fossology(FOSS_URL, FOSS_TOKEN, username)
 
     .. note::

--- a/fossology/jobs.py
+++ b/fossology/jobs.py
@@ -83,7 +83,6 @@ class Jobs:
         >>>         "nomos": True,
         >>>         "ojo": True,
         >>>         "package": True,
-        >>>         "patent": True,
         >>>     },
         >>>     "decider": {
         >>>         "nomos_monk": True,

--- a/fossology/obj.py
+++ b/fossology/obj.py
@@ -75,7 +75,7 @@ class Agents(object):
     :param nomos: run nomos agent on every upload
     :param ojo: run ojo agent on every upload
     :param package: run package agent on every upload
-    :param patent: run patent agent on every upload
+    :param **kwargs: handle any other agent provided by the fossology instance
     :type bucket: boolean
     :type copyright_email_author: boolean
     :type ecc: boolean
@@ -85,7 +85,7 @@ class Agents(object):
     :type nomos: boolean
     :type ojo: boolean
     :type package: boolean
-    :type patent: boolean
+    :type **kwargs: key word argument
     """
 
     def __init__(
@@ -99,7 +99,7 @@ class Agents(object):
         nomos,
         ojo,
         package,
-        patent,
+        **kwargs,
     ):
         self.bucket = bucket
         self.copyright_email_author = copyright_email_author
@@ -110,7 +110,8 @@ class Agents(object):
         self.nomos = nomos
         self.ojo = ojo
         self.package = package
-        self.patent = patent
+        for key, value in kwargs.items():
+            self.additional_agents = {key: value}
 
     def to_dict(self):
         """Get a directory with the agent configuration
@@ -118,7 +119,7 @@ class Agents(object):
         :return: the agents configured for the current user
         :rtype: dict
         """
-        agents = {
+        generic_agents = {
             "bucket": self.bucket,
             "copyright_email_author": self.copyright_email_author,
             "ecc": self.ecc,
@@ -128,8 +129,12 @@ class Agents(object):
             "nomos": self.nomos,
             "ojo": self.ojo,
             "package": self.package,
-            "patent": self.patent,
         }
+        try:
+            agents = {**generic_agents, **self.additional_agents}
+        except AttributeError:
+            agents = generic_agents
+
         return agents
 
     @classmethod


### PR DESCRIPTION
Fossology instances can use different type of scan agents which are reflected in the `/user` endpoint.

This patch add the possibility to map any kind of unspecified agents to the user `Agents` object.