### PR TITLE
added wait time before checking in upload_file

### DIFF
--- a/fossology/uploads.py
+++ b/fossology/uploads.py
@@ -54,6 +54,7 @@ class Uploads:
         access_level=None,
         ignore_scm=False,
         group=None,
+        wait_time_before_checking=None
     ):
         """Upload a file to FOSSology
 
@@ -159,6 +160,8 @@ class Uploads:
             return
 
         if response.status_code == 201:
+            if wait_time_before_checking:
+                time.sleep(wait_time_before_checking)
             try:
                 upload = self.detail_upload(response.json()["message"])
                 logger.info(


### PR DESCRIPTION
solves issue #42 (After calling file upload API, the method upload_file does not wait even a second to try to get upload data to check if upload has been successful. This implies that one has to wait 60 sec almost every time she uploads a package)