### PR TITLE
feat(0.2.0): get report name from HTTP header

### DIFF
--- a/docs-source/conf.py
+++ b/docs-source/conf.py
@@ -22,8 +22,8 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "fossology"
 copyright = "2020, Siemens AG"
 
-# The full version, including alpha/beta/rc tags
-release = "0.1.4"
+# The full version, including major/minor/patch tags
+release = "0.2.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fossology"
-version = "0.1.4"
+version = "0.2.0"
 description = "A library to automate Fossology from Python scripts"
 authors = ["Marion Deveaud <marion.deveaud@siemens.com>"]
 license = "MIT License"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -7,7 +7,7 @@ import mimetypes
 
 from pathlib import Path
 from test_base import foss, logger
-from test_uploads import get_upload, do_upload, upload_filename
+from test_uploads import get_upload, do_upload
 from fossology.exceptions import FossologyApiError
 from fossology.obj import ReportFormat
 
@@ -28,39 +28,20 @@ class TestFossologyReport(unittest.TestCase):
 
         try:
             # Plain text
-            report = foss.download_report(report_id)
-            report_path = Path.cwd() / "tests/files"
-            report_name = upload_filename + ".spdx-report.rdf"
-            with open(report_path / report_name, "w+") as report_file:
+            report, name = foss.download_report(report_id)
+            report_path = Path.cwd() / "tests/files" / name
+            with open(report_path, "w+") as report_file:
                 report_file.write(report)
 
-            filetype = mimetypes.guess_type(report_path / report_name)
-            report_stat = os.stat(report_path / report_name)
+            filetype = mimetypes.guess_type(report_path)
+            report_stat = os.stat(report_path)
             self.assertGreater(report_stat.st_size, 0, "Downloaded report is empty")
             self.assertIn(
                 filetype[0],
                 ("application/rdf+xml", "application/xml"),
                 "Downloaded report is not a RDF/XML file",
             )
-            Path(report_path / report_name).unlink()
-        except FossologyApiError as error:
-            logger.error(error.message)
-
-        try:
-            # Zip
-            report = foss.download_report(report_id, as_zip=True)
-            report_path = Path.cwd() / "tests/files"
-            report_name = upload_filename + ".spdx-report.rdf.zip"
-            with open(report_path / report_name, "w+") as report_file:
-                report_file.write(report)
-
-            filetype = mimetypes.guess_type(report_path / report_name)
-            report_stat = os.stat(report_path / report_name)
-            self.assertGreater(report_stat.st_size, 0, "Downloaded report is empty")
-            self.assertEqual(
-                filetype[0], "application/zip", "Downloaded report is not a ZIP file"
-            )
-            Path(report_path / report_name).unlink()
+            Path(report_path).unlink()
         except FossologyApiError as error:
             logger.error(error.message)
 


### PR DESCRIPTION
Small but breaking change in the API: get the report name from the server via HTTP header.