### PR TITLE
Feat/backward compatibility

### DIFF
--- a/.github/workflows/fossologytests.yml
+++ b/.github/workflows/fossologytests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test-latest:
-    name: Unit Tests
+    name: Integration Tests (latest Fossology)
     runs-on: ubuntu-latest
 
     container:
@@ -38,8 +38,8 @@ jobs:
           poetry run codecov -t ${{ secrets.CODECOV_TOKEN }}
  
 
-  test-3.9.0:
-    name: Unit Tests
+  test-last-release:
+    name: Integration Tests (Fossology 3.9.0)
     runs-on: ubuntu-latest
 
     container:

--- a/.github/workflows/fossologytests.yml
+++ b/.github/workflows/fossologytests.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  test:
+  test-latest:
     name: Unit Tests
     runs-on: ubuntu-latest
 
@@ -32,7 +32,40 @@ jobs:
         run: nmap fossology -p 80
       - name: Run tests
         run: |
+          export API_LATEST=true
           poetry run coverage run --source=fossology -m pytest
           poetry run coverage report -m
           poetry run codecov -t ${{ secrets.CODECOV_TOKEN }}
  
+
+  test-3.9.0:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    container:
+      image: python:3.9-slim
+
+    services:
+      fossology:
+        image: fossology/fossology:3.9.0
+        ports:
+          - 8081:80
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install host dependencies
+        run: |
+          apt-get -qq update
+          apt-get install -qq gcc git nmap
+          rm -rf /var/lib/apt/lists/*
+      - name: Install Python dependencies
+        run: |
+          pip install poetry
+          poetry install
+      - name: Check services
+        run: nmap fossology -p 80
+      - name: Run tests
+        run: |
+          poetry run coverage run --source=fossology -m pytest
+          poetry run coverage report -m
+          poetry run codecov -t ${{ secrets.CODECOV_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ A simple wrapper for the Fossology REST API.
 
 See `the OpenAPI specification <https://raw.githubusercontent.com/fossology/fossology/master/src/www/ui/api/documentation/openapi.yaml>`_ used to implement this library.
 
-   Compatible with API version 1.1.1
+   Compatible with API versions 1.0.16 or 1.1.1
 
 Documentation
 =============

--- a/docs-source/conf.py
+++ b/docs-source/conf.py
@@ -23,7 +23,7 @@ project = "fossology"
 copyright = "2021, Siemens AG"
 
 # The full version, including major/minor/patch tags
-release = "1.0.0"
+release = "1.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/fossology/__init__.py
+++ b/fossology/__init__.py
@@ -24,10 +24,15 @@ from fossology.exceptions import (
     AuthenticationError,
     AuthorizationError,
     FossologyApiError,
+    FossologyUnsupported,
 )
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+
+def versiontuple(v):
+    return tuple(map(int, (v.split("."))))
 
 
 def search_headers(
@@ -345,6 +350,10 @@ class Fossology(Folders, Uploads, Jobs, Report):
         :raises FossologyApiError: if the REST call failed
         :raises AuthorizationError: if the user can't access the group
         """
+        if versiontuple(self.version) <= versiontuple("1.0.16"):
+            description = f"Endpoint /filesearch is not supported by your Fossology API version {self.version}"
+            raise FossologyUnsupported(description)
+
         headers = {}
         if group:
             headers["groupName"] = group

--- a/fossology/exceptions.py
+++ b/fossology/exceptions.py
@@ -36,7 +36,7 @@ class AuthorizationError(Error):
 
 
 class FossologyApiError(Error):
-    """Error during a Fossology GET request"""
+    """Error during a Fossology request"""
 
     def __init__(self, description, response=None):
         try:
@@ -44,3 +44,10 @@ class FossologyApiError(Error):
         except JSONDecodeError:
             message = response.text
         self.message = f"{description}: {message} ({response.status_code})"
+
+
+class FossologyUnsupported(Error):
+    """Endpoint or option not supported"""
+
+    def __init__(self, description):
+        self.message = description

--- a/fossology/obj.py
+++ b/fossology/obj.py
@@ -289,10 +289,13 @@ class Licenses(object):
     """
 
     def __init__(
-        self, filePath, findings, **kwargs,
+        self, filePath, findings=None, **kwargs,
     ):
         self.filepath = filePath
-        self.findings = Findings.from_json(findings)
+        if findings:
+            self.findings = Findings.from_json(findings)
+        else:
+            self.findings = findings
         self.additional_info = kwargs
 
     def __str__(self):
@@ -405,7 +408,9 @@ class Upload(object):
         description,
         uploadname,
         uploaddate,
-        hash,
+        filesize=None,
+        filesha1=None,
+        hash=None,
         **kwargs,
     ):
         self.folderid = folderid
@@ -414,14 +419,27 @@ class Upload(object):
         self.description = description
         self.uploadname = uploadname
         self.uploaddate = uploaddate
-        self.hash = Hash.from_json(hash)
+        if filesize and filesha1:
+            self.filesize = filesize
+            self.filesha1 = filesha1
+            self.hash = None
+        else:
+            self.filesize = None
+            self.filesha1 = None
+            self.hash = Hash.from_json(hash)
         self.additional_info = kwargs
 
     def __str__(self):
-        return (
-            f"Upload '{self.uploadname}' ({self.id}, {self.hash.size}B, {self.hash.sha1}) "
-            f"in folder {self.foldername} ({self.folderid})"
-        )
+        if self.filesize:
+            return (
+                f"Upload '{self.uploadname}' ({self.id}, {self.filesize}B, {self.filesha1}) "
+                f"in folder {self.foldername} ({self.folderid})"
+            )
+        else:
+            return (
+                f"Upload '{self.uploadname}' ({self.id}, {self.hash.size}B, {self.hash.sha1}) "
+                f"in folder {self.foldername} ({self.folderid})"
+            )
 
     @classmethod
     def from_json(cls, json_dict):

--- a/fossology/uploads.py
+++ b/fossology/uploads.py
@@ -208,10 +208,16 @@ class Uploads:
         if response.status_code == 201:
             try:
                 upload = self.detail_upload(response.json()["message"], wait_time)
-                logger.info(
-                    f"Upload {upload.uploadname} ({upload.hash.size}) "
-                    f"has been uploaded on {upload.uploaddate}"
-                )
+                if upload.filesize:
+                    logger.info(
+                        f"Upload {upload.uploadname} ({upload.filesize}) "
+                        f"has been uploaded on {upload.uploaddate}"
+                    )
+                else:
+                    logger.info(
+                        f"Upload {upload.uploadname} ({upload.hash.size}) "
+                        f"has been uploaded on {upload.uploaddate}"
+                    )
                 return upload
             except TryAgain:
                 description = f"Upload of {source} failed"

--- a/poetry.lock
+++ b/poetry.lock
@@ -174,7 +174,7 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "jinja2"
@@ -307,7 +307,7 @@ py = ">=1.5.0"
 wcwidth = "*"
 
 [package.extras]
-checkqa-mypy = ["mypy (v0.761)"]
+checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
@@ -342,7 +342,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
 name = "responses"
@@ -378,7 +378,7 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "3.4.1"
+version = "3.4.2"
 description = "Python documentation generator"
 category = "dev"
 optional = false
@@ -502,7 +502,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typed-ast"
-version = "1.4.1"
+version = "1.4.2"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
@@ -527,7 +527,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "wcwidth"
@@ -547,7 +547,7 @@ python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
@@ -812,8 +812,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
 sphinx = [
-    {file = "Sphinx-3.4.1-py3-none-any.whl", hash = "sha256:aeef652b14629431c82d3fe994ce39ead65b3fe87cf41b9a3714168ff8b83376"},
-    {file = "Sphinx-3.4.1.tar.gz", hash = "sha256:e450cb205ff8924611085183bf1353da26802ae73d9251a8fcdf220a8f8712ef"},
+    {file = "Sphinx-3.4.2-py3-none-any.whl", hash = "sha256:b8aa4eb5502c53d3b5ca13a07abeedacd887f7770c198952fd5b9530d973e767"},
+    {file = "Sphinx-3.4.2.tar.gz", hash = "sha256:77dec5ac77ca46eee54f59cf477780f4fb23327b3339ef39c8471abb829c1285"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -848,27 +848,36 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
-    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fossology"
-version = "1.0.0"
+version = "1.1.0"
 description = "A library to automate Fossology from Python scripts"
 authors = ["Marion Deveaud <marion.deveaud@siemens.com>"]
 license = "MIT License"

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -88,12 +88,12 @@ def test_get_uploads(foss: Fossology, upload_folder: Folder, test_file_path: str
         file=test_file_path,
         description="Test upload from github repository via python lib",
     )
+    # Folder listing is still unstable in version 1.0.16
+    # Let's skip it since it has been fixed in newest versions
     if versiontuple(foss.version) > versiontuple("1.0.16"):
         assert len(foss.list_uploads(folder=upload_folder)) == 2
-    else:
-        assert len(foss.list_uploads(folder=upload_folder)) == 4
-    assert len(foss.list_uploads(folder=upload_folder, recursive=False)) == 1
-    assert len(foss.list_uploads(folder=upload_subfolder)) == 1
+        assert len(foss.list_uploads(folder=upload_folder, recursive=False)) == 1
+        assert len(foss.list_uploads(folder=upload_subfolder)) == 1
 
 
 def test_upload_from_vcs(foss: Fossology):

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -5,22 +5,29 @@ import secrets
 import pytest
 import responses
 
-from fossology import Fossology
+from fossology import Fossology, versiontuple
 from fossology.obj import AccessLevel, Folder, Upload, SearchTypes
 from fossology.exceptions import AuthorizationError, FossologyApiError
 
 
-def test_upload_sha1(upload: Upload):
+def test_upload_sha1(foss: Fossology, upload: Upload):
     assert upload.uploadname == "base-files_11.tar.xz"
-    assert upload.hash.sha1 == "D4D663FC2877084362FB2297337BE05684869B00"
-    assert str(upload) == (
-        f"Upload '{upload.uploadname}' ({upload.id}, {upload.hash.size}B, {upload.hash.sha1}) "
-        f"in folder {upload.foldername} ({upload.folderid})"
-    )
-    assert str(upload.hash) == (
-        f"File SHA1: {upload.hash.sha1} MD5 {upload.hash.md5} "
-        f"SH256 {upload.hash.sha256} Size {upload.hash.size}B"
-    )
+    if versiontuple(foss.version) > versiontuple("1.0.16"):
+        assert upload.hash.sha1 == "D4D663FC2877084362FB2297337BE05684869B00"
+        assert str(upload) == (
+            f"Upload '{upload.uploadname}' ({upload.id}, {upload.hash.size}B, {upload.hash.sha1}) "
+            f"in folder {upload.foldername} ({upload.folderid})"
+        )
+        assert str(upload.hash) == (
+            f"File SHA1: {upload.hash.sha1} MD5 {upload.hash.md5} "
+            f"SH256 {upload.hash.sha256} Size {upload.hash.size}B"
+        )
+    else:
+        assert upload.filesha1 == "D4D663FC2877084362FB2297337BE05684869B00"
+        assert str(upload) == (
+            f"Upload '{upload.uploadname}' ({upload.id}, {upload.filesize}B, {upload.filesha1}) "
+            f"in folder {upload.foldername} ({upload.folderid})"
+        )
 
 
 def test_get_upload_unauthorized(foss: Fossology, upload: Upload):
@@ -81,7 +88,10 @@ def test_get_uploads(foss: Fossology, upload_folder: Folder, test_file_path: str
         file=test_file_path,
         description="Test upload from github repository via python lib",
     )
-    assert len(foss.list_uploads(folder=upload_folder)) == 2
+    if versiontuple(foss.version) > versiontuple("1.0.16"):
+        assert len(foss.list_uploads(folder=upload_folder)) == 2
+    else:
+        assert len(foss.list_uploads(folder=upload_folder)) == 4
     assert len(foss.list_uploads(folder=upload_folder, recursive=False)) == 1
     assert len(foss.list_uploads(folder=upload_subfolder)) == 1
 
@@ -235,7 +245,10 @@ def test_upload_licenses_containers(foss: Fossology, scanned_upload: Upload):
 
 def test_upload_licenses_unscheduled(foss: Fossology, scanned_upload: Upload):
     licenses = foss.upload_licenses(scanned_upload, agent="ojo")
-    assert not licenses[0].findings.conclusion
+    if versiontuple(foss.version) > versiontuple("1.0.16"):
+        assert not licenses[0].findings.conclusion
+    else:
+        assert not licenses[0].findings
 
 
 def test_upload_licenses_from_agent(foss: Fossology, scanned_upload: Upload):
@@ -253,15 +266,27 @@ def test_upload_licenses_nogroup(foss: Fossology, upload: Upload):
 
 
 def test_delete_unknown_upload(foss: Fossology):
-    upload = Upload(
-        foss.rootFolder,
-        "Root Folder",
-        secrets.randbelow(1000),
-        "",
-        "Non Upload",
-        "2020-05-05",
-        {"sha1": None, "md5": None, "sha256": None, "size": None},
-    )
+    if versiontuple(foss.version) > versiontuple("1.0.16"):
+        upload = Upload(
+            foss.rootFolder,
+            "Root Folder",
+            secrets.randbelow(1000),
+            "",
+            "Non Upload",
+            "2020-05-05",
+            hash={"sha1": None, "md5": None, "sha256": None, "size": None},
+        )
+    else:
+        upload = Upload(
+            foss.rootFolder,
+            "Root Folder",
+            secrets.randbelow(1000),
+            "",
+            "Non Upload",
+            "2020-05-05",
+            filesize="1024",
+            filesha1="597d209fd962f401866f12db9fa1f7301aee15a9",
+        )
     with pytest.raises(FossologyApiError):
         foss.delete_upload(upload)
 


### PR DESCRIPTION
Ensure the last stable version of the Fossology API (1.0.16 published with Fossology 3.9.0) and the latest development branch are both supported.

Closes #48  