### PR TITLE
fix typehints for compatibility with python < 3.9

### DIFF
--- a/fossology/license.py
+++ b/fossology/license.py
@@ -4,6 +4,7 @@
 import json
 from json.decoder import JSONDecodeError
 import logging
+from typing import List, Tuple
 
 import fossology
 from fossology.exceptions import FossologyApiError, FossologyUnsupported
@@ -36,7 +37,7 @@ class LicenseEndpoint:
         page_size: int = 100,
         page: int = 1,
         all_pages: bool = False,
-    ) -> list[License]:
+    ) -> List[License]:
         """Get all license from the DB
 
         API Endpoint: GET /license
@@ -52,7 +53,7 @@ class LicenseEndpoint:
         :type page: int
         :type all_pages: boolean
         :return: a list of licenses
-        :rtype: list[License]
+        :rtype: List[License]
         :raises FossologyApiError: if the REST call failed
         """
         if fossology.versiontuple(self.version) < fossology.versiontuple("1.3.0"):
@@ -95,7 +96,7 @@ class LicenseEndpoint:
 
     def detail_license(
         self, shortname, group=None
-    ) -> tuple[int, License, list[Obligation]]:
+    ) -> Tuple[int, License, List[Obligation]]:
         """Get a license from the DB
 
         API Endpoint: GET /license/{shortname}
@@ -105,7 +106,7 @@ class LicenseEndpoint:
         :type name: str
         :type group: int
         :return: the license id, the license data and the associated obligations
-        :rtype: tuple(int, License, list[Obligation])
+        :rtype: tuple(int, License, List[Obligation])
         :raises FossologyApiError: if the REST call failed
         """
         if fossology.versiontuple(self.version) < fossology.versiontuple("1.3.0"):


### PR DESCRIPTION
Supported python versions are from 3.6 onward, but currently type hints with built-ins (supported only by python 3.9) are used.

Fossology-python should use "old" type hints for compatibility with older versions of python.

This PR fixes #78 