### PR TITLE
Feat add sample workflow documentation

### DIFF
--- a/docs-source/sample_workflow.rst
+++ b/docs-source/sample_workflow.rst
@@ -16,6 +16,7 @@ Needed imports and Variables
 ============================
 
 
+>>> import os 
 >>> import sys
 >>> import pathlib 
 >>> import secrets
@@ -25,6 +26,8 @@ Needed imports and Variables
 >>> from fossology.obj import Group, AccessLevel, TokenScope
 >>> from fossology.exceptions  import FossologyApiError
 >>> FOSSOLOGY_SERVER = "http://fossology/repo"
+>>> os.environ["FOSSOLOGY_USER"] = "fossy"
+>>> os.environ["FOSSOLOGY_USER_PASS"] = "fossy"
 
 Create JWT Token
 ================
@@ -34,10 +37,13 @@ Create token - if not already done - and store it in local file for reuse.
 
 >>> path_to_token_file = pathlib.Path.cwd() / '.token'
 >>> if not path_to_token_file.exists():
-...   #print("Enter your Fossology credentials, e.g. in the test environment 'username: fossy' and 'password: fossy'")
-...   #username = input("username: ")
-...   #pw = getpass()
-...   username, pw = "fossy","fossy"
+...   if os.environ["FOSSOLOGY_USER"] and os.environ["FOSSOLGY_USER_PASS"]:
+...       username =  os.environ["FOSSOLOGY_USER"]
+...       pw =  os.environ["FOSSOLOGY_USER_PASS"]
+...   else:
+...       print("Enter your Fossology credentials, e.g. in the test environment 'username: fossy' and 'password: fossy'")
+...       username = input("username: ")
+...       pw = getpass()
 ...   token = fossology_token(
 ...        FOSSOLOGY_SERVER,
 ...        username,

--- a/docs-source/sample_workflow.rst
+++ b/docs-source/sample_workflow.rst
@@ -46,7 +46,7 @@ Create token - if not already done - and store it in local file for reuse.
 ...        TokenScope.WRITE,
 ...    )
 ...   with open(path_to_token_file, "w") as fp:
-...        fp.write(token)
+...        len = fp.write(token)
 ... else:
 ...   # Load the token
 ...   with open(".token", "r") as fp:
@@ -108,7 +108,6 @@ upload it to the server.
 >>> path_to_upload_file = pathlib.Path.cwd() / filename
 >>> if not path_to_upload_file.exists():
 ...    url = "https://github.com/fossology/fossology-python/blob/master/tests/files/base-files_11.tar.xz"
-...    print(f"Get a local copy of {filename} from {url}")
 ...    r = requests.get(url)
 ...    with open(path_to_upload_file, "wb") as fp: 
 ...        fp.write(r.content)

--- a/docs-source/sample_workflow.rst
+++ b/docs-source/sample_workflow.rst
@@ -24,7 +24,6 @@ Needed imports and Variables
 >>> from fossology import Fossology, fossology_token
 >>> from fossology.obj import Group, AccessLevel, TokenScope
 >>> from fossology.exceptions  import FossologyApiError
-
 >>> FOSSOLOGY_SERVER = "http://fossology/repo"
 
 Create JWT Token
@@ -35,7 +34,7 @@ Create token - if not already done - and store it in local file for reuse.
 
 >>> path_to_token_file = pathlib.Path.cwd() / '.token'
 >>> if not path_to_token_file.exists():
-...   print("Enter your Fossology credentials, e.g. in the test environment 'username: fossy' and 'password: fossy'")
+...   #print("Enter your Fossology credentials, e.g. in the test environment 'username: fossy' and 'password: fossy'")
 ...   #username = input("username: ")
 ...   #pw = getpass()
 ...   username, pw = "fossy","fossy"

--- a/docs-source/sample_workflow.rst
+++ b/docs-source/sample_workflow.rst
@@ -110,7 +110,7 @@ upload it to the server.
 ...    url = "https://github.com/fossology/fossology-python/blob/master/tests/files/base-files_11.tar.xz"
 ...    r = requests.get(url)
 ...    with open(path_to_upload_file, "wb") as fp: 
-...        fp.write(r.content)
+...        len = fp.write(r.content)
 >>> my_upload = foss.upload_file(
 ...     test_folder,
 ...     file=path_to_upload_file,
@@ -189,7 +189,6 @@ report created with id...
 report downloaded...
 >>> with open(name, "wb") as fp: 
 ...    len = fp.write(content)
->>> fp.close()
 >>> print(f"report was written to file {name}.") # doctest: +ELLIPSIS  
 report was written to file...
 

--- a/docs-source/sample_workflow.rst
+++ b/docs-source/sample_workflow.rst
@@ -15,46 +15,43 @@ Sample Workflow
 Needed imports and Variables
 ============================
 
-.. code-block:: python
 
-    import sys
-    import pathlib 
-    import secrets
-    from getpass import getpass
-    import requests
-    from fossology import Fossology, fossology_token
-    from fossology.obj import Group, AccessLevel, TokenScope
-    from fossology.exceptions  import FossologyApiError
+>>> import sys
+>>> import pathlib 
+>>> import secrets
+>>> from getpass import getpass
+>>> import requests
+>>> from fossology import Fossology, fossology_token
+>>> from fossology.obj import Group, AccessLevel, TokenScope
+>>> from fossology.exceptions  import FossologyApiError
 
-    FOSSOLOGY_SERVER = "http://fossology/repo"
+>>> FOSSOLOGY_SERVER = "http://fossology/repo"
 
 Create JWT Token
 ================
 
 Create token - if not already done - and store it in local file for reuse.
 
-.. code-block:: python
 
-  path_to_token_file = pathlib.Path.cwd() / '.token'
-  if not path_to_token_file.exists():
-    print("Enter your Fossology credentials, e.g. in the test environment 'username: fossy' and 'password: fossy'")
-    username = input("username: ")
-    pw = getpass()
-    token = fossology_token(
-        FOSSOLOGY_SERVER,
-        username,
-        pw,
-        secrets.token_urlsafe(8), # TOKEN_NAME seen in the database
-        TokenScope.WRITE,
-    )
-    with open(path_to_token_file, "w") as fp:
-        fp.write(token)
-    print("token written to .token")
-  else:
-    print("Reuse token from .token")
-    # Load the token
-    with open(".token", "r") as fp:
-        token = fp.read()
+>>> path_to_token_file = pathlib.Path.cwd() / '.token'
+>>> if not path_to_token_file.exists():
+...   print("Enter your Fossology credentials, e.g. in the test environment 'username: fossy' and 'password: fossy'")
+...   #username = input("username: ")
+...   #pw = getpass()
+...   username, pw = "fossy","fossy"
+...   token = fossology_token(
+...        FOSSOLOGY_SERVER,
+...        username,
+...        pw,
+...        secrets.token_urlsafe(8), # TOKEN_NAME seen in the database
+...        TokenScope.WRITE,
+...    )
+...   with open(path_to_token_file, "w") as fp:
+...        fp.write(token)
+... else:
+...   # Load the token
+...   with open(".token", "r") as fp:
+...       token = fp.read()
 
 
 Login to the Fossology Server
@@ -62,10 +59,10 @@ Login to the Fossology Server
 
  Create the Fossology Instance.
 
-.. code-block:: python
 
-  foss = Fossology(FOSSOLOGY_SERVER, token)
-  print(f"Logged in as user {foss.user.name}")
+>>> foss = Fossology(FOSSOLOGY_SERVER, token)
+>>> print(f"Logged in as user {foss.user.name}")
+Logged in as user fossy
 
 
 Create Folder If needed 
@@ -73,35 +70,33 @@ Create Folder If needed
 
 Create Folder if needed.
 
-.. code-block:: python
 
-  folder_name = "AwesomeFossFolder"
-  folder_desc = "AwesomeProjectSources"
-  test_folder = foss.create_folder(
-        foss.rootFolder, folder_name, description=folder_desc
-    )
-  print(f"Created {test_folder.name} with description {test_folder.description}")
+>>> folder_name = "AwesomeFossFolder"
+>>> folder_desc = "AwesomeProjectSources"
+>>> test_folder = foss.create_folder(
+...       foss.rootFolder, folder_name, description=folder_desc
+...   )
+>>> print(f"Created {test_folder.name} with description {test_folder.description}")
+Created AwesomeFossFolder with description AwesomeProjectSources
 
 Create Group If needed 
 =======================
 
 Create Group If needed.
 
-.. code-block:: python
-
-  group_name = "clearing"
-  # The name of the group created by `create_group` can be used in subsequent
-  # call to restrict access to resources from this group, see 
-  # https://fossology.github.io/fossology-python/groups.html for further resources
-  try:
-    foss.create_group(group_name)
-  except FossologyApiError as e:
-    if "Details: Group already exists.  Not added." in e.message:
-      print(f" group {group_name} already created")
-    else:
-      raise e
-   print(f"group named {group_name} is created")
-
+>>> group_name = "clearing"
+>>> # The name of the group created by `create_group` can be used in subsequent
+>>> # call to restrict access to resources from this group, see 
+>>> # https://fossology.github.io/fossology-python/groups.html for further resources
+>>> try:
+...   foss.create_group(group_name)
+... except FossologyApiError as e:
+...   if "Details: Group already exists.  Not added." in e.message:
+...     pass
+...   else:
+...     raise e
+>>> print(f"group named {group_name} is created")
+group named clearing is created
 
 
 Upload File 
@@ -109,24 +104,22 @@ Upload File
 We first get an example file from our github repository testenvironment and then
 upload it to the server. 
 
-.. code-block:: python
 
-   filename = "my_base-files_11.tar.xz"
-   path_to_upload_file = pathlib.Path.cwd() / filename
-   if not path_to_upload_file.exists():
-     url = "https://github.com/fossology/fossology-python/blob/master/tests/files/base-files_11.tar.xz"
-     print(f"Get a local copy of {filename} from {url}")
-     r = requests.get(url)
-     with open(path_to_upload_file, "wb") as fp: 
-       fp.write(r.content)
-
-   my_upload = foss.upload_file(
-     test_folder,
-     file=path_to_upload_file,
-     description="Test upload via fossology-python lib",
-     group=group_name,
-     access_level=AccessLevel.PUBLIC,
-   )   
+>>> filename = "my_base-files_11.tar.xz"
+>>> path_to_upload_file = pathlib.Path.cwd() / filename
+>>> if not path_to_upload_file.exists():
+...    url = "https://github.com/fossology/fossology-python/blob/master/tests/files/base-files_11.tar.xz"
+...    print(f"Get a local copy of {filename} from {url}")
+...    r = requests.get(url)
+...    with open(path_to_upload_file, "wb") as fp: 
+...        fp.write(r.content)
+>>> my_upload = foss.upload_file(
+...     test_folder,
+...     file=path_to_upload_file,
+...     description="Test upload via fossology-python lib",
+...     group=group_name,
+...     access_level=AccessLevel.PUBLIC,
+... )   
 
 
 Start default scan jobs
@@ -144,45 +137,43 @@ The doings of this step are best explained showing the corresponding web interfa
 
 The below given job_specification resemble the buttons activated in the web-ui.
 
-.. code-block:: python
 
-  job_specification = {
-        "analysis": {
-            "bucket": True,
-            "copyright_email_author": True,
-            "ecc": True,
-            "keyword": True,
-            "monk": True,
-            "mime": True,
-            "monk": True,
-            "nomos": True,
-            "ojo": True,
-            "package": True,
-            "specific_agent": True,
-        },
-        "decider": {
-            "nomos_monk": True,
-            "bulk_reused": True,
-            "new_scanner": True,
-            "ojo_decider": True,
-        },
-        "reuse": {
-            "reuse_upload": 0,
-            "reuse_group": 0,
-            "reuse_main": True,
-            "reuse_enhanced": True,
-            "reuse_report": True,
-            "reuse_copyright": True,
-        },
-    }
-
-  detailed_job = foss.schedule_jobs(
-    test_folder,
-    my_upload,
-    job_specification
-  )
-
-  print(f"scan job {detailed_job} set up")
+>>> job_specification = {
+...        "analysis": {
+...            "bucket": True,
+...            "copyright_email_author": True,
+...            "ecc": True,
+...            "keyword": True,
+...            "monk": True,
+...            "mime": True,
+...            "monk": True,
+...            "nomos": True,
+...            "ojo": True,
+...            "package": True,
+...            "specific_agent": True,
+...        },
+...        "decider": {
+...            "nomos_monk": True,
+...            "bulk_reused": True,
+...            "new_scanner": True,
+...            "ojo_decider": True,
+...        },
+...        "reuse": {
+...            "reuse_upload": 0,
+...            "reuse_group": 0,
+...            "reuse_main": True,
+...            "reuse_enhanced": True,
+...            "reuse_report": True,
+...            "reuse_copyright": True,
+...        },
+...    }
+>>> detailed_job = foss.schedule_jobs(
+...    test_folder,
+...    my_upload,
+...    job_specification
+...  )
+>>> print(f"scan job {detailed_job} set up") # doctest: +ELLIPSIS
+scan job...
 
 
 Generate report
@@ -191,13 +182,16 @@ Generate report
 Generate a  report based on the uploaded archive  and the findings 
 of the analysis - download the report and store it on disk.
 
-.. code-block:: python
 
-  report_id = foss.generate_report(my_upload, group=group_name)
-  print(f"report created with id {report_id} ")
-  content, name = foss.download_report(report_id, group_name)
-  print(f"report downloaded with name {name}")
-  with open(name, "wb") as fp:
-    fp.write(content)
-  print(f"report was written to file {name}.")
+>>> report_id = foss.generate_report(my_upload, group=group_name)
+>>> print(f"report created with id {report_id} ") # doctest: +ELLIPSIS
+report created with id...
+>>> content, name = foss.download_report(report_id, group_name)
+>>> print(f"report downloaded with name {name}") # doctest: +ELLIPSIS  
+report downloaded...
+>>> with open(name, "wb") as fp: 
+...    len = fp.write(content)
+>>> fp.close()
+>>> print(f"report was written to file {name}.") # doctest: +ELLIPSIS  
+report was written to file...
 

--- a/fossology/__init__.py
+++ b/fossology/__init__.py
@@ -78,9 +78,9 @@ def fossology_token(
 
     :Example:
 
-    >>> from fossology import fossology_token
-    >>> from fossology.obj import TokenScope
-    >>> token = fossology_token("https://fossology.example.com", "Me", "MyPassword", "MyToken")
+    >>> from fossology import fossology_token # doctest: +SKIP
+    >>> from fossology.obj import TokenScope # doctest: +SKIP
+    >>> token = fossology_token("https://fossology.example.com", "Me", "MyPassword", "MyToken") # doctest: +SKIP
 
 
     :param url: the URL of the Fossology server
@@ -135,7 +135,7 @@ class Fossology(Folders, Groups, LicenseEndpoint, Uploads, Jobs, Report):
     :Example:
 
     >>> from fossology import Fossology
-    >>> foss = Fossology(FOSS_URL, FOSS_TOKEN, username)
+    >>> foss = Fossology(FOSS_URL, FOSS_TOKEN, username) # doctest: +SKIP
 
     :param url: URL of the Fossology instance
     :param token: The API token generated using the Fossology UI

--- a/fossology/jobs.py
+++ b/fossology/jobs.py
@@ -110,35 +110,35 @@ class Jobs:
         Job specifications `spec` are added to the request body,
         following options are available:
 
-        >>> {
-        >>>     "analysis": {
-        >>>         "bucket": True,
-        >>>         "copyright_email_author": True,
-        >>>         "ecc": True,
-        >>>         "keyword": True,
-        >>>         "monk": True,
-        >>>         "mime": True,
-        >>>         "monk": True,
-        >>>         "nomos": True,
-        >>>         "ojo": True,
-        >>>         "package": True,
-        >>>         "specific_agent": True,
-        >>>     },
-        >>>     "decider": {
-        >>>         "nomos_monk": True,
-        >>>         "bulk_reused": True,
-        >>>         "new_scanner": True,
-        >>>         "ojo_decider": True
-        >>>     },
-        >>>     "reuse": {
-        >>>         "reuse_upload": 0,
-        >>>         "reuse_group": 0,
-        >>>         "reuse_main": True,
-        >>>         "reuse_enhanced": True
-        >>>         "reuse_report": True
-        >>>         "reuse_copyright": True
-        >>>     }
-        >>> }
+        >>> job_spec = {
+        ...     "analysis": {
+        ...         "bucket": True,
+        ...         "copyright_email_author": True,
+        ...         "ecc": True,
+        ...         "keyword": True,
+        ...         "monk": True,
+        ...         "mime": True,
+        ...         "monk": True,
+        ...         "nomos": True,
+        ...         "ojo": True,
+        ...         "package": True,
+        ...         "specific_agent": True,
+        ...     },
+        ...     "decider": {
+        ...         "nomos_monk": True,
+        ...         "bulk_reused": True,
+        ...         "new_scanner": True,
+        ...         "ojo_decider": True
+        ...     },
+        ...     "reuse": {
+        ...         "reuse_upload": 0,
+        ...         "reuse_group": 0,
+        ...         "reuse_main": True,
+        ...         "reuse_enhanced": True,
+        ...         "reuse_report": True,
+        ...         "reuse_copyright": True,
+        ...     }
+        ... }
 
         :param folder: the upload folder
         :param upload: the upload for which jobs will be scheduled

--- a/fossology/license.py
+++ b/fossology/license.py
@@ -138,14 +138,14 @@ class LicenseEndpoint:
         License data are added to the request body, here is an example:
 
         >>> new_license = License(
-        >>>     "GPL-1.0",
-        >>>     "GNU General Public License 1.0",
-        >>>     "Text of the license...",
-        >>>     "http://www.gnu.org/licenses/gpl-1.0.txt",
-        >>>     "red"
-        >>>     "false"
-        >>> )
-        >>> foss.add_license(new_license, merge_request=True)
+        ...     "GPL-1.0",
+        ...     "GNU General Public License 1.0",
+        ...     "Text of the license...",
+        ...     "http://www.gnu.org/licenses/gpl-1.0.txt",
+        ...     "red",
+        ...     "false"
+        ... )
+        >>> foss.add_license(new_license, merge_request=True) # doctest: +SKIP
 
         :param license: the license data
         :param merge_request: open a merge request for the license candidate? (default: False)

--- a/fossology/report.py
+++ b/fossology/report.py
@@ -73,15 +73,15 @@ class Report:
 
         :Example:
 
-        >>> from fossology.api import Fossology
+        >>> from fossology import Fossology
         >>>
-        >>> foss = Fossology(FOSS_URL, FOSS_TOKEN, username)
+        >>> foss = Fossology(FOSS_URL, FOSS_TOKEN, username) # doctest: +SKIP
         >>>
         >>> # Generate a report for upload 1
-        >>> report_id = foss.generate_report(foss.detail_upload(1))
-        >>> report_content, report_name = foss.download_report(report_id)
+        >>> report_id = foss.generate_report(foss.detail_upload(1)) # doctest: +SKIP
+        >>> report_content, report_name = foss.download_report(report_id) # doctest: +SKIP
         >>> with open(report_name, "wb") as report_file:
-        >>>     report_file.write(report_content)
+        ...     report_file.write(report_content) # doctest: +SKIP
 
         :param report_id: the id of the generated report
         :param group: the group name to choose while downloading a specific report (default: None)

--- a/fossology/uploads.py
+++ b/fossology/uploads.py
@@ -35,7 +35,7 @@ class Uploads:
         :Examples:
 
         >>> # Wait up to 20 minutes until the upload is ready
-        >>> long_upload = u.detail_upload(1, wait_time=120) # doctest: +SKIP
+        >>> long_upload = detail_upload(1, wait_time=120) # doctest: +SKIP
 
         >>> # Wait up to 5 minutes until the upload is ready
         >>> long_upload = detail_upload(1, wait_time=30) # doctest: +SKIP

--- a/fossology/uploads.py
+++ b/fossology/uploads.py
@@ -1,6 +1,5 @@
 # Copyright 2019-2021 Siemens AG
 # SPDX-License-Identifier: MIT
-
 import json
 import logging
 import time
@@ -36,10 +35,10 @@ class Uploads:
         :Examples:
 
         >>> # Wait up to 20 minutes until the upload is ready
-        >>> long_upload = detail_upload(1, wait_time=120)
+        >>> long_upload = u.detail_upload(1, wait_time=120) # doctest: +SKIP
 
         >>> # Wait up to 5 minutes until the upload is ready
-        >>> long_upload = detail_upload(1, wait_time=30)
+        >>> long_upload = detail_upload(1, wait_time=30) # doctest: +SKIP
 
         :param upload_id: the id of the upload
         :param group: the group the upload shall belong to
@@ -103,58 +102,58 @@ class Uploads:
 
         >>> from fossology import Fossology
         >>> from fossology.obj import AccessLevel
-        >>> foss = Fossology(FOSS_URL, FOSS_TOKEN, username)
+        >>> foss = Fossology(FOSS_URL, FOSS_TOKEN, username) # doctest: +SKIP
         >>> my_upload = foss.upload_file(
-                foss.rootFolder,
-                file="my-package.zip",
-                description="My product package",
-                access_level=AccessLevel.PUBLIC,
-            )
+        ...        foss.rootFolder,
+        ...        file="my-package.zip",
+        ...        description="My product package",
+        ...        access_level=AccessLevel.PUBLIC,
+        ...    )  # doctest: +SKIP
 
         :Example for a VCS upload:
 
         >>> vcs = {
-                "vcsType": "git",
-                "vcsUrl": "https://github.com/fossology/fossology-python",
-                "vcsName": "fossology-python-github-master",
-                "vcsUsername": "",
-                "vcsPassword": "",
-            }
+        ...        "vcsType": "git",
+        ...        "vcsUrl": "https://github.com/fossology/fossology-python",
+        ...        "vcsName": "fossology-python-github-master",
+        ...        "vcsUsername": "",
+        ...        "vcsPassword": "",
+        ...    }
         >>> vcs_upload = foss.upload_file(
-                foss.rootFolder,
-                vcs=vcs,
-                description="Upload from VCS",
-                access_level=AccessLevel.PUBLIC,
-            )
+        ...        foss.rootFolder,
+        ...        vcs=vcs,
+        ...        description="Upload from VCS",
+        ...        access_level=AccessLevel.PUBLIC,
+        ...    )  # doctest: +SKIP
 
         :Example for a URL upload:
 
         >>> url = {
-                "url": "https://github.com/fossology/fossology-python/archive/master.zip",
-                "name": "fossology-python-master.zip",
-                "accept": "zip",
-                "reject": "",
-                "maxRecursionDepth": "1",
-            }
+        ...        "url": "https://github.com/fossology/fossology-python/archive/master.zip",
+        ...        "name": "fossology-python-master.zip",
+        ...        "accept": "zip",
+        ...        "reject": "",
+        ...        "maxRecursionDepth": "1",
+        ...    }
         >>> url_upload = foss.upload_file(
-                foss.rootFolder,
-                url=url,
-                description="Upload from URL",
-                access_level=AccessLevel.PUBLIC,
-            )
+        ...        foss.rootFolder,
+        ...        url=url,
+        ...        description="Upload from URL",
+        ...        access_level=AccessLevel.PUBLIC,
+        ...    )  # doctest: +SKIP
 
         :Example for a SERVER upload:
 
         >>> server = {
-                "path": "/tmp/fossology-python",
-                "name": "fossology-python",
-            }
+        ...        "path": "/tmp/fossology-python",
+        ...        "name": "fossology-python",
+        ...    }
         >>> server_upload = foss.upload_file(
-                foss.rootFolder,
-                server=server,
-                description="Upload from SERVER",
-                access_level=AccessLevel.PUBLIC,
-            )
+        ...        foss.rootFolder,
+        ...        server=server,
+        ...        description="Upload from SERVER",
+        ...        access_level=AccessLevel.PUBLIC,
+        ...    )  # doctest: +SKIP
 
 
         :param folder: the upload Fossology folder

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,7 +77,7 @@ python-versions = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.3"
+version = "2.0.4"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -100,7 +100,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "codecov"
-version = "2.1.11"
+version = "2.1.12"
 description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
 category = "dev"
 optional = false
@@ -169,7 +169,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.6.1"
+version = "4.8.1"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -183,6 +183,14 @@ zipp = ">=0.5"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "isort"
@@ -228,14 +236,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "more-itertools"
-version = "8.8.0"
-description = "More routines for operating on iterables, beyond itertools"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
@@ -256,17 +256,18 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "pluggy"
-version = "0.13.1"
+version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -294,7 +295,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pygments"
-version = "2.9.0"
+version = "2.10.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
@@ -310,25 +311,24 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "5.4.3"
+version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=17.4.0"
+attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-more-itertools = ">=4.0.0"
+iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
-py = ">=1.5.0"
-wcwidth = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
 
 [package.extras]
-checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
@@ -341,7 +341,7 @@ python-versions = "*"
 
 [[package]]
 name = "regex"
-version = "2021.7.6"
+version = "2021.8.28"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -399,7 +399,7 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "4.1.1"
+version = "4.1.2"
 description = "Python documentation generator"
 category = "dev"
 optional = false
@@ -528,7 +528,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.0"
+version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "dev"
 optional = false
@@ -548,14 +548,6 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "wcwidth"
-version = "0.2.5"
-description = "Measures the displayed width of unicode strings in a terminal"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "zipp"
 version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -570,7 +562,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "3844bbf020816a414b95a409c04b643feb7117a790a0770a0c909f34d7648d89"
+content-hash = "b4a318730d7d8126785ba029893a1dc00c57c97b888f7fa71c8787fc4eab49f0"
 
 [metadata.files]
 alabaster = [
@@ -602,20 +594,21 @@ certifi = [
     {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.3.tar.gz", hash = "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"},
-    {file = "charset_normalizer-2.0.3-py3-none-any.whl", hash = "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1"},
+    {file = "charset-normalizer-2.0.4.tar.gz", hash = "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"},
+    {file = "charset_normalizer-2.0.4-py3-none-any.whl", hash = "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b"},
 ]
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
     {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
 ]
 codecov = [
-    {file = "codecov-2.1.11-py2.py3-none-any.whl", hash = "sha256:ba8553a82942ce37d4da92b70ffd6d54cf635fc1793ab0a7dc3fecd6ebfb3df8"},
-    {file = "codecov-2.1.11-py3.8.egg", hash = "sha256:e95901d4350e99fc39c8353efa450050d2446c55bac91d90fcfd2354e19a6aef"},
-    {file = "codecov-2.1.11.tar.gz", hash = "sha256:6cde272454009d27355f9434f4e49f238c0273b216beda8472a65dc4957f473b"},
+    {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
+    {file = "codecov-2.1.12-py3.8.egg", hash = "sha256:782a8e5352f22593cbc5427a35320b99490eb24d9dcfa2155fd99d2b75cfb635"},
+    {file = "codecov-2.1.12.tar.gz", hash = "sha256:a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -688,8 +681,12 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.6.1-py3-none-any.whl", hash = "sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e"},
-    {file = "importlib_metadata-4.6.1.tar.gz", hash = "sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac"},
+    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
+    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
     {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
@@ -739,10 +736,6 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
-more-itertools = [
-    {file = "more-itertools-8.8.0.tar.gz", hash = "sha256:83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a"},
-    {file = "more_itertools-8.8.0-py3-none-any.whl", hash = "sha256:2cf89ec599962f2ddc4d568a05defc40e0a587fbc10d5989713638864c36be4d"},
-]
 packaging = [
     {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
     {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
@@ -752,8 +745,8 @@ pathspec = [
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
-    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -768,63 +761,63 @@ pyflakes = [
     {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pygments = [
-    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
-    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
+    {file = "Pygments-2.10.0-py3-none-any.whl", hash = "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380"},
+    {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
-    {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 regex = [
-    {file = "regex-2021.7.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:ed693137a9187052fc46eedfafdcb74e09917166362af4cc4fddc3b31560e93d"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99d8ab206a5270c1002bfcf25c51bf329ca951e5a169f3b43214fdda1f0b5f0d"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407"},
-    {file = "regex-2021.7.6-cp36-cp36m-win32.whl", hash = "sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b"},
-    {file = "regex-2021.7.6-cp36-cp36m-win_amd64.whl", hash = "sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb"},
-    {file = "regex-2021.7.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:564a4c8a29435d1f2256ba247a0315325ea63335508ad8ed938a4f14c4116a5d"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:59c00bb8dd8775473cbfb967925ad2c3ecc8886b3b2d0c90a8e2707e06c743f0"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:9a854b916806c7e3b40e6616ac9e85d3cdb7649d9e6590653deb5b341a736cec"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:db2b7df831c3187a37f3bb80ec095f249fa276dbe09abd3d35297fc250385694"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895"},
-    {file = "regex-2021.7.6-cp37-cp37m-win32.whl", hash = "sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5"},
-    {file = "regex-2021.7.6-cp37-cp37m-win_amd64.whl", hash = "sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f"},
-    {file = "regex-2021.7.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux1_i686.whl", hash = "sha256:422dec1e7cbb2efbbe50e3f1de36b82906def93ed48da12d1714cabcd993d7f0"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cbe23b323988a04c3e5b0c387fe3f8f363bf06c0680daf775875d979e376bd26"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:0eb2c6e0fcec5e0f1d3bcc1133556563222a2ffd2211945d7b1480c1b1a42a6f"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1c78780bf46d620ff4fff40728f98b8afd8b8e35c3efd638c7df67be2d5cddbf"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068"},
-    {file = "regex-2021.7.6-cp38-cp38-win32.whl", hash = "sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0"},
-    {file = "regex-2021.7.6-cp38-cp38-win_amd64.whl", hash = "sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4"},
-    {file = "regex-2021.7.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4f64fc59fd5b10557f6cd0937e1597af022ad9b27d454e182485f1db3008f417"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:89e5528803566af4df368df2d6f503c84fbfb8249e6631c7b025fe23e6bd0cde"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2366fe0479ca0e9afa534174faa2beae87847d208d457d200183f28c74eaea59"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f9392a4555f3e4cb45310a65b403d86b589adc773898c25a39184b1ba4db8985"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3"},
-    {file = "regex-2021.7.6-cp39-cp39-win32.whl", hash = "sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035"},
-    {file = "regex-2021.7.6-cp39-cp39-win_amd64.whl", hash = "sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c"},
-    {file = "regex-2021.7.6.tar.gz", hash = "sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d"},
+    {file = "regex-2021.8.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308"},
+    {file = "regex-2021.8.28-cp310-cp310-win32.whl", hash = "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed"},
+    {file = "regex-2021.8.28-cp310-cp310-win_amd64.whl", hash = "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8"},
+    {file = "regex-2021.8.28-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f"},
+    {file = "regex-2021.8.28-cp36-cp36m-win32.whl", hash = "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354"},
+    {file = "regex-2021.8.28-cp36-cp36m-win_amd64.whl", hash = "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645"},
+    {file = "regex-2021.8.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906"},
+    {file = "regex-2021.8.28-cp37-cp37m-win32.whl", hash = "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a"},
+    {file = "regex-2021.8.28-cp37-cp37m-win_amd64.whl", hash = "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc"},
+    {file = "regex-2021.8.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e"},
+    {file = "regex-2021.8.28-cp38-cp38-win32.whl", hash = "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d"},
+    {file = "regex-2021.8.28-cp38-cp38-win_amd64.whl", hash = "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2"},
+    {file = "regex-2021.8.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed"},
+    {file = "regex-2021.8.28-cp39-cp39-win32.whl", hash = "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374"},
+    {file = "regex-2021.8.28-cp39-cp39-win_amd64.whl", hash = "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73"},
+    {file = "regex-2021.8.28.tar.gz", hash = "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -843,8 +836,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 sphinx = [
-    {file = "Sphinx-4.1.1-py3-none-any.whl", hash = "sha256:3d513088236eef51e5b0adb78b0492eb22cc3b8ccdb0b36dd021173b365d4454"},
-    {file = "Sphinx-4.1.1.tar.gz", hash = "sha256:23c846a1841af998cb736218539bb86d16f5eb95f5760b1966abcd2d584e62b8"},
+    {file = "Sphinx-4.1.2-py3-none-any.whl", hash = "sha256:46d52c6cee13fec44744b8c01ed692c18a640f6910a725cbb938bc36e8d64544"},
+    {file = "Sphinx-4.1.2.tar.gz", hash = "sha256:3092d929cd807926d846018f2ace47ba2f3b671b309c7a89cd3306e80c826b13"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -911,17 +904,13 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
-    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
-    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
     {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
-]
-wcwidth = [
-    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
-    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 zipp = [
     {file = "zipp-3.5.0-py3-none-any.whl", hash = "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
 [tool.isort]
 profile = "black"
 
+[tool.pytest.ini_options]
+addopts = "--doctest-glob='*.rst' --doctest-modules"
+
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = ">=2.22.0"
@@ -33,7 +36,7 @@ black = "^19.10b0"
 coverage = "^5.1"
 codecov = "^2.0.22"
 pyflakes = "^2.2.0"
-pytest = "^5.4.3"
+pytest = "^6.2.5"
 responses = "^0.10.15"
 isort = "^5.7.0"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+# if pytest >6.0 is used the entry [tool.pytest.ini_options] in
+# pyproject.toml could be used
+
+[pytest]
+#minversion = 6.0
+addopts = --doctest-glob='*.rst' --doctest-modules  

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-# if pytest >6.0 is used the entry [tool.pytest.ini_options] in
-# pyproject.toml could be used
-
-[pytest]
-#minversion = 6.0
-addopts = --doctest-glob='*.rst' --doctest-modules  


### PR DESCRIPTION
- doc-source/sample_workflow.rst has been rewritten to use doctests
- fossology/*.py files with doctest entries have been rewritten so that tests are executed.
some line-tests are skipped - needs discussion on which could be enabled with appropriate effort.

- a pytest.ini was created adding. pytest opts, so that doctests are executed whenever pytest is called. 
Whenever pytest>=6 is used that file can be deleted and the "addopt entry" can migrate to pyproject.toml

Tests pass till they call "poetry run codecov -t ${{ secrets.CODECOV_TOKEN }}" in fossologytests.yml. The secret is not defined in my environment - that is why i did the pull request. 
Maybe this call should only be executed if it is executed in the repository "fossology/fossology-python" 

 