### PR TITLE
docs: add AI-assisted contribution guidelines and fix codecov for for…

### DIFF
--- a/.github/workflows/fossologytests.yml
+++ b/.github/workflows/fossologytests.yml
@@ -43,6 +43,6 @@ jobs:
         run: |
           poetry run coverage run --source=fossology -m pytest
           poetry run coverage report -m
-      - name: upload codecoverage results only if we are on the repository fossology/fossology-python 
-        if: ${{ github.repository == 'fossology/fossology-python' }}
+      - name: upload codecoverage results only if the PR originates from the upstream repository
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: poetry run codecov -t ${{ secrets.CODECOV_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,8 @@ Fossology Python also offers a command line interface to simplify interactions w
 Contribute
 ==========
 
+
+
 Develop
 -------
 
@@ -197,6 +199,21 @@ Develop
 
    To avoid running the whole testsuite during development of a new branch with changing only touching the code related
    to the CLI, name your branch ``feat/cli-{something}`` and only the ``test_foss_cli_*`` will run in the pull request context.
+
+**AI-Assisted Contributions**
+
+   AI coding agents are active in this repository. If you are an AI agent or using AI-assisted tooling,
+   please follow these guidelines:
+
+   -  **Do not pollute the issue tracker** with lengthy explanations for simple fixes or API extensions.
+      The issue tracker is reserved for discussing significant design decisions and feature proposals.
+
+   -  **Keep pull requests concise.** The maintainers do not need a full report of every change — the
+      code speaks for itself. Minimize verbose descriptions and auto-generated summaries.
+
+   -  **All new extensions must include test cases.** Every new feature or API extension must be properly
+      covered by tests that provide confidence in the patch. Pull requests without adequate test coverage
+      will not be accepted.
 
 Build
 -----


### PR DESCRIPTION
…k PRs

Add an "AI-Assisted Contributions" section to README.rst to set expectations for AI agents and AI-assisted tooling active in this repository: avoid noisy issues for simple fixes, keep PR descriptions concise, and always provide test coverage for new extensions.

Fix the codecov upload condition in the API Tests workflow. The previous guard (`github.repository == 'fossology/fossology-python'`) was always true — even for fork PRs — because `github.repository` refers to the base repository, not the PR source. Replace it with a comparison of `github.event.pull_request.head.repo.full_name` against `github.repository` so the codecov step is skipped when the PR originates from a fork where the CODECOV_TOKEN secret is unavailable.