### PR TITLE
fix: correct status codes for add and delete group member

### DIFF
--- a/fossology/groups.py
+++ b/fossology/groups.py
@@ -119,7 +119,7 @@ class Groups:
         response = self.session.post(
             f"{self.api}/groups/{group_id}/user/{user_id}", json=data
         )
-        if response.status_code == 200:
+        if response.status_code == 201:
             logger.info(f"User {user_id} has been added to group {group_id}.")
         elif response.status_code == 400:
             logger.info(f"User {user_id} is already a member of group {group_id}.")
@@ -179,7 +179,7 @@ class Groups:
         :raises FossologyApiError: if the REST call failed
         """
         response = self.session.delete(f"{self.api}/groups/{group_id}/user/{user_id}")
-        if response.status_code == 200:
+        if response.status_code == 202:
             logger.info(f"User {user_id} will be removed from group {group_id}.")
         elif response.status_code == 400:
             description = f"Validation error while removing member {user_id} from group {group_id}."

--- a/fossology/groups.py
+++ b/fossology/groups.py
@@ -119,7 +119,7 @@ class Groups:
         response = self.session.post(
             f"{self.api}/groups/{group_id}/user/{user_id}", json=data
         )
-        if response.status_code == 201:
+        if response.status_code in (200, 201):
             logger.info(f"User {user_id} has been added to group {group_id}.")
         elif response.status_code == 400:
             logger.info(f"User {user_id} is already a member of group {group_id}.")
@@ -179,7 +179,7 @@ class Groups:
         :raises FossologyApiError: if the REST call failed
         """
         response = self.session.delete(f"{self.api}/groups/{group_id}/user/{user_id}")
-        if response.status_code == 202:
+        if response.status_code in (200, 202):
             logger.info(f"User {user_id} will be removed from group {group_id}.")
         elif response.status_code == 400:
             description = f"Validation error while removing member {user_id} from group {group_id}."


### PR DESCRIPTION
fixes #179

this fixes an issue where add_group_member and delete_group_member were throwing errors on success. the api returns 201 and 202 instead of 200, so this just updates the checks to match what the api actually sends back.
