### PR TITLE
feat(license): wrap POST /license/import-csv endpoint

### DIFF
--- a/fossology/license.py
+++ b/fossology/license.py
@@ -158,6 +158,43 @@ class LicenseEndpoint:
             description = f"Error while adding new license {license.shortName}"
             raise FossologyApiError(description, response)
 
+    def import_licenses_csv(
+        self,
+        csv_file: str,
+        delimiter: str = ",",
+        enclosure: str = '"',
+    ) -> str:
+        """Import licenses from a CSV file.
+
+        API Endpoint: POST /license/import-csv
+
+        :param csv_file: local path to the CSV file containing license data
+        :param delimiter: field delimiter used in the CSV file (default: ",")
+        :param enclosure: field enclosure character used in the CSV file (default: '"')
+        :type csv_file: str
+        :type delimiter: str
+        :type enclosure: str
+        :return: the API response message (multi-line summary of inserted /
+            already-existing / skipped rows)
+        :rtype: str
+        :raises FossologyApiError: if the REST call failed
+        """
+        data = {"delimiter": delimiter, "enclosure": enclosure}
+        with open(csv_file, "rb") as fp:
+            response = self.session.post(
+                f"{self.api}/license/import-csv",
+                data=data,
+                files={"file_input": fp},
+            )
+
+        if response.status_code == 200:
+            message = response.json()["message"]
+            logger.info(f"License CSV {csv_file} imported: {message}")
+            return message
+
+        description = f"Unable to import licenses from {csv_file}"
+        raise FossologyApiError(description, response)
+
     def update_license(
         self,
         shortname: str,

--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -32,6 +32,60 @@ def test_another_license():
     return License(shortname, fullname, text, url, risk, False)
 
 
+def test_import_licenses_csv(foss: fossology.Fossology, tmp_path):
+    csv_path = tmp_path / "licenses.csv"
+    csv_path.write_text(
+        "shortname,fullname,text,parent,report,url,risk,group,notes\n"
+        "CsvImportTestLic,Csv Import Test Lic,License text body,,white,"
+        "http://example.com/csv,5,,\n"
+    )
+    message = foss.import_licenses_csv(str(csv_path))
+    # Server returns multi-line summary; either freshly inserted or already
+    # present from a prior run — both are valid outcomes for an idempotent import.
+    assert "CsvImportTestLic" in message
+    assert "Read csv: 1 licenses" in message
+
+
+@responses.activate
+def test_import_licenses_csv_error(
+    foss_server: str, foss: fossology.Fossology, tmp_path
+):
+    responses.add(
+        responses.POST,
+        f"{foss_server}/api/v1/license/import-csv",
+        status=400,
+    )
+    csv_path = tmp_path / "bad.csv"
+    csv_path.write_text("not really a csv\n")
+    with pytest.raises(FossologyApiError) as excinfo:
+        foss.import_licenses_csv(str(csv_path))
+    assert f"Unable to import licenses from {csv_path}" in str(excinfo.value)
+
+
+@responses.activate
+def test_import_licenses_csv_request_payload(
+    foss_server: str, foss: fossology.Fossology, tmp_path
+):
+    responses.add(
+        responses.POST,
+        f"{foss_server}/api/v1/license/import-csv",
+        status=200,
+        json={"code": 200, "message": "head okay\nRead csv: 1 licenses", "type": "INFO"},
+    )
+    csv_path = tmp_path / "lic.csv"
+    csv_path.write_text("shortname,fullname\nFoo,Foo License\n")
+
+    message = foss.import_licenses_csv(str(csv_path), delimiter=";", enclosure="'")
+
+    assert "Read csv: 1 licenses" in message
+    assert len(responses.calls) == 1
+    body = responses.calls[0].request.body.decode("utf-8", errors="ignore")
+    assert 'name="file_input"' in body
+    assert 'name="delimiter"' in body and "\r\n\r\n;\r\n" in body
+    assert 'name="enclosure"' in body and "\r\n\r\n'\r\n" in body
+    assert "shortname,fullname\nFoo,Foo License" in body
+
+
 @responses.activate
 def test_detail_license_error(foss_server: str, foss: fossology.Fossology):
     responses.add(responses.GET, f"{foss_server}/api/v1/license/Blah", status=500)


### PR DESCRIPTION
Refs #52.

Wraps the `POST /license/import-csv` endpoint as `LicenseEndpoint.import_licenses_csv()`.

Performs a multipart upload of a CSV file with optional `delimiter` (default `","`) and `enclosure` (default `"\""`), returning the server's multi-line summary message indicating inserted and already-existing rows.

The implementation matches the live contract verified against Fossology 4.4.0:

- Endpoint path is `/license/import-csv` (the OpenAPI spec was renamed from the original `/license/import` in fossology/fossology#2292; the current spec lives alongside `/license/export-csv`, `/license/import-json`, `/license/export-json`)

- Required field: `file_input`; optional `delimiter`, `enclosure`

- 200 success → `Info` schema with multi-line message

- 400 → validation error

Tests cover the live happy path by round-tripping a small CSV against the container (the server is idempotent on duplicate shortnames, so repeated test runs do not pollute state), as well as a mocked `400 Bad Request` error path.