### PR TITLE
feat(uploads): wrap one-shot nomos, monk and ceu scan endpoints

### DIFF
--- a/fossology/uploads.py
+++ b/fossology/uploads.py
@@ -817,3 +817,72 @@ class Uploads:
                 f"API error while getting permissions for upload {upload.uploadname}."
             )
             raise FossologyApiError(description, response)
+
+    def _run_oneshot(self, scanner: str, file: str) -> dict:
+        """Run a one-shot scan on a single file without storing the results.
+
+        :param scanner: the scanner to run ("nomos", "monk" or "ceu")
+        :param file: local path to the file to scan
+        :type scanner: str
+        :type file: str
+        :return: the scanner result (``data`` findings and ``highlights``)
+        :rtype: dict
+        :raises FossologyApiError: if the REST call failed
+        """
+        with open(file, "rb") as fp:
+            response = self.session.post(  # type: ignore
+                f"{self.api}/uploads/oneshot/{scanner}",  # type: ignore
+                files={"fileInput": fp},
+            )
+
+        if response.status_code == 200:
+            logger.info(f"One-shot {scanner} scan completed for {file}")
+            return response.json()
+
+        description = f"One-shot {scanner} scan failed for {file}"
+        raise FossologyApiError(description, response)
+
+    def upload_oneshot_nomos(self, file: str) -> dict:
+        """Run a one-shot nomos (license) scan on a single file.
+
+        The file is scanned without creating a persistent upload.
+
+        API Endpoint: POST /uploads/oneshot/nomos
+
+        :param file: local path to the file to scan
+        :type file: str
+        :return: the scanner result (``data`` findings and ``highlights``)
+        :rtype: dict
+        :raises FossologyApiError: if the REST call failed
+        """
+        return self._run_oneshot("nomos", file)
+
+    def upload_oneshot_monk(self, file: str) -> dict:
+        """Run a one-shot monk (license) scan on a single file.
+
+        The file is scanned without creating a persistent upload.
+
+        API Endpoint: POST /uploads/oneshot/monk
+
+        :param file: local path to the file to scan
+        :type file: str
+        :return: the scanner result (``data`` findings and ``highlights``)
+        :rtype: dict
+        :raises FossologyApiError: if the REST call failed
+        """
+        return self._run_oneshot("monk", file)
+
+    def upload_oneshot_ceu(self, file: str) -> dict:
+        """Run a one-shot copyright/email/URL scan on a single file.
+
+        The file is scanned without creating a persistent upload.
+
+        API Endpoint: POST /uploads/oneshot/ceu
+
+        :param file: local path to the file to scan
+        :type file: str
+        :return: the scanner result (``data`` findings and ``highlights``)
+        :rtype: dict
+        :raises FossologyApiError: if the REST call failed
+        """
+        return self._run_oneshot("ceu", file)

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -420,3 +420,57 @@ def test_download_upload_error(foss_server: str, foss: Fossology, upload: Upload
     with pytest.raises(FossologyApiError) as excinfo:
         foss.download_upload(upload)
     assert f"Unable to download upload {upload.id}" in str(excinfo.value)
+
+
+def test_upload_oneshot_nomos(foss: Fossology, tmp_path):
+    scan_file = tmp_path / "mit.txt"
+    scan_file.write_text("SPDX-License-Identifier: MIT\n")
+    result = foss.upload_oneshot_nomos(str(scan_file))
+    assert isinstance(result, dict)
+
+
+def test_upload_oneshot_monk(foss: Fossology, tmp_path):
+    scan_file = tmp_path / "mit.txt"
+    scan_file.write_text("SPDX-License-Identifier: MIT\n")
+    result = foss.upload_oneshot_monk(str(scan_file))
+    assert isinstance(result, dict)
+
+
+def test_upload_oneshot_ceu(foss: Fossology, tmp_path):
+    scan_file = tmp_path / "code.txt"
+    scan_file.write_text("Copyright (c) 2024 Example Inc. https://example.com\n")
+    result = foss.upload_oneshot_ceu(str(scan_file))
+    assert isinstance(result, dict)
+
+
+@responses.activate
+def test_upload_oneshot_request_payload(
+    foss: Fossology, foss_server: str, tmp_path
+):
+    responses.add(
+        responses.POST,
+        f"{foss_server}/api/v1/uploads/oneshot/nomos",
+        status=200,
+        json={"data": ["MIT"], "highlights": []},
+    )
+    scan_file = tmp_path / "mit.txt"
+    scan_file.write_text("SPDX-License-Identifier: MIT\n")
+    result = foss.upload_oneshot_nomos(str(scan_file))
+    assert result["data"] == ["MIT"]
+    assert len(responses.calls) == 1
+    body = responses.calls[0].request.body.decode("utf-8", errors="ignore")
+    assert 'name="fileInput"' in body
+
+
+@responses.activate
+def test_upload_oneshot_error(foss: Fossology, foss_server: str, tmp_path):
+    responses.add(
+        responses.POST,
+        f"{foss_server}/api/v1/uploads/oneshot/monk",
+        status=500,
+    )
+    scan_file = tmp_path / "mit.txt"
+    scan_file.write_text("some text\n")
+    with pytest.raises(FossologyApiError) as excinfo:
+        foss.upload_oneshot_monk(str(scan_file))
+    assert f"One-shot monk scan failed for {scan_file}" in str(excinfo.value)


### PR DESCRIPTION
Refs #52.

Adds one-shot scan wrappers (`upload_oneshot_nomos` / `upload_oneshot_monk` / `upload_oneshot_ceu`) for `POST /uploads/oneshot/{scanner}`.

Closed: these routes are API 1.6.2 / master-only and do not exist in fossology 4.4.0 (the version CI pins), so they 404 there. Will revisit when the CI target includes them.