### PR TITLE
fix(report): stop filename parsing from swallowing filename* parameter

### DIFF
--- a/fossology/report.py
+++ b/fossology/report.py
@@ -205,7 +205,7 @@ class Report:
 
         if response.status_code == 200:
             content = response.headers["Content-Disposition"]
-            report_name_pattern = "(^attachment; filename=)(\"|')?([^\"|']*)(\"|'$)?"
+            report_name_pattern = "(^attachment; filename=)(\"|')?([^\"|';]*)(\"|'$)?"
             report_name = re.match(report_name_pattern, content).group(3)  # type: ignore
             return response.content, report_name
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -246,3 +246,23 @@ def test_download_report_filename_with_single_quotes(foss_server: str, foss: Fos
     )
     _, report_name = foss.download_report(report_id)
     assert report_name == "Report_FileName.docx"
+
+
+@responses.activate
+def test_download_report_filename_with_extended_parameter(
+    foss_server: str, foss: Fossology
+):
+    report_id = "1"
+    filename = "CLIXML_cifs-utils_2%3A6.14-1ubuntu0.3-ubuntu-combined.tar.bz2.xml"
+    responses.add(
+        responses.GET,
+        f"{foss_server}/api/v1/report/{report_id}",
+        status=200,
+        headers={
+            "Content-Disposition": (
+                f"attachment; filename={filename}; filename*=UTF-8''{filename}"
+            )
+        },
+    )
+    _, report_name = foss.download_report(report_id)
+    assert report_name == filename


### PR DESCRIPTION
Closes: https://github.com/fossology/fossology-python/issues/205