### PR TITLE
docs: corrected api endpoints in docstring that is fixed typos in folders.py/create_folder() and uploads.py/change_upload_permissions

### DIFF
--- a/fossology/folders.py
+++ b/fossology/folders.py
@@ -80,7 +80,7 @@ class Folders:
         The name of the new folder must be unique under the same parent.
         Folder names are case insensitive.
 
-        API Endpoint: POST /folders/{id}
+        API Endpoint: POST /folders
 
         :param parent: the parent folder
         :param name: the name of the folder

--- a/fossology/uploads.py
+++ b/fossology/uploads.py
@@ -868,7 +868,7 @@ class Uploads:
     ):
         """Change the permission of an upload
 
-        API Endpoint: PUT /uploads/{id}/permission
+        API Endpoint: PUT /uploads/{upload.id}/permissions
 
         :param upload: the upload to update
         :param group: the group you want to add or edit permission for this upload

--- a/fossology/uploads.py
+++ b/fossology/uploads.py
@@ -868,7 +868,7 @@ class Uploads:
     ):
         """Change the permission of an upload
 
-        API Endpoint: PUT /uploads/{upload.id}/permissions
+        API Endpoint: PUT /uploads/{id}/permissions
 
         :param upload: the upload to update
         :param group: the group you want to add or edit permission for this upload


### PR DESCRIPTION
Closes issue #208 